### PR TITLE
require just the vendor folder (Symfony 4.2 compat)

### DIFF
--- a/composer_stats.php
+++ b/composer_stats.php
@@ -102,7 +102,8 @@ function writePath(string $path): void
             'vendor/composer/composer',
             '../vendor/composer',
             '../vendor/composer/composer',
-            '../../composer'
+            '../../composer',
+            '../vendor'
         ];
 
         $autoloadFiles = null;


### PR DESCRIPTION
require just the vendor folder (Symfony 4.2 compat)

Without this change on a Symfony app you just get a white page of death. 

With this change everything works as it should.